### PR TITLE
Add CI Pipeline for iOS Build and Test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,13 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Create GoogleService-Info.plist
+        env:
+          GOOGLE_SERVICE_PLIST: ${{ secrets.GOOGLE_SERVICE_PLIST }}
+        run: |
+          mkdir -p Sources
+          echo "$GOOGLE_SERVICE_PLIST" > Sources/GoogleService-Info.plist
+
       - name: Build and Test
         uses: sersoft-gmbh/xcodebuild-action@v3.2.0
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,46 @@
+name: iOS Build and Test
+
+on:
+  pull_request:
+    branches:
+      - main
+      - develop
+
+jobs:
+  build-and-test:
+    runs-on: macos-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Build and Test
+        uses: sersoft-gmbh/xcodebuild-action@v3.2.0
+        with:
+          project: MediStock.xcodeproj
+          scheme: MediStock
+          destination: 'platform=iOS Simulator,name=iPhone 16 Pro'
+          action: test
+          result-bundle-path: './TestResults/TestResults.xcresult'
+
+      - name: Debug - List files in TestResults directory
+        run: |
+          echo "Listing files in the workspace:"
+          ls -la .
+          echo "Listing files in TestResults directory:"
+          ls -la TestResults || echo "TestResults directory not found"
+        if: always()
+
+      - name: Process Test Results
+        uses: kishikawakatsumi/xcresulttool@v1
+        with:
+          path: ./TestResults/TestResults.xcresult
+          upload-bundles: 'never'
+        if: always()
+
+      - name: Upload Test Results Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results
+          path: ./TestResults/TestResults.xcresult
+        if: always()

--- a/MediStock.xcodeproj/xcshareddata/xcschemes/MediStock.xcscheme
+++ b/MediStock.xcodeproj/xcshareddata/xcschemes/MediStock.xcscheme
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1620"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "53E0D8922C06084700DE1134"
+               BuildableName = "MediStock.app"
+               BlueprintName = "MediStock"
+               ReferencedContainer = "container:MediStock.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "53E0D8A22C06084900DE1134"
+               BuildableName = "MediStockTests.xctest"
+               BlueprintName = "MediStockTests"
+               ReferencedContainer = "container:MediStock.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "53E0D8AC2C06084900DE1134"
+               BuildableName = "MediStockUITests.xctest"
+               BlueprintName = "MediStockUITests"
+               ReferencedContainer = "container:MediStock.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "53E0D8922C06084700DE1134"
+            BuildableName = "MediStock.app"
+            BlueprintName = "MediStock"
+            ReferencedContainer = "container:MediStock.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "53E0D8922C06084700DE1134"
+            BuildableName = "MediStock.app"
+            BlueprintName = "MediStock"
+            ReferencedContainer = "container:MediStock.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>


### PR DESCRIPTION
### Pull Request: Add CI Pipeline for iOS Build and Test

Closes #2

#### Description
This pull request introduces a Continuous Integration (CI) pipeline using GitHub Actions to automate the building and testing of the MediStock iOS app. The workflow triggers on pull requests targeting the `main` and `develop` branches, ensuring code quality and stability before merging.

#### Implementations Made
- Added `.github/workflows/ci.yml` to define the CI process.
- Configured a workflow triggered by pull requests to `main` and `develop` branches.
- Set up the workflow to run on `macos-latest` for compatibility with Xcode and iOS.
- Implemented specific steps for building, testing, and handling test results.

#### Workflow Details
The CI pipeline includes the following steps:

1. **Checkout Repository**  
   - Uses `actions/checkout@v4` to fetch the repository contents.

2. **Build and Test**  
   - Uses `sersoft-gmbh/xcodebuild-action@v3.2.0` with the following settings:  
     - Project: `MediStock.xcodeproj`  
     - Scheme: `MediStock`  
     - Destination: iOS Simulator (`iPhone 16 Pro`)  
     - Action: `test`  
     - Result bundle path: `./TestResults/TestResults.xcresult`

3. **Process Test Results**  
   - Uses `kishikawakatsumi/xcresulttool@v1` to analyze and generate reports from `TestResults.xcresult`.  
   - Configured with `upload-bundles: 'never'` to skip uploading bundles.  
   - Runs with `if: always()` to ensure execution even after failures.

4. **Upload Test Results Artifact**  
   - Uses `actions/upload-artifact@v4` to store test results as an artifact named `test-results`.  
   - Path: `./TestResults/TestResults.xcresult`  
   - Runs with `if: always()` to make results available in both success and failure cases.
